### PR TITLE
 fix the parquet link to the metatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ geoglows.egg-info
 dist
 .pypirc
 *.parquet
+*.pyc

--- a/geoglows/data.py
+++ b/geoglows/data.py
@@ -205,6 +205,7 @@ def metadata_tables(columns: list = None, metadata_table_path: str = None) -> pd
     Retrieves the master table of rivers metadata and properties as a pandas DataFrame
     Args:
         columns (list): optional subset of columns names to read from the parquet
+        metadata_table_path (str): optional path to a local copy of the metadata table
 
     Returns:
         pd.DataFrame

--- a/geoglows/data.py
+++ b/geoglows/data.py
@@ -200,7 +200,7 @@ def return_periods(river_id: int or list, *, format: str = 'df', method: str = '
 
 
 # model config and supplementary data
-def metadata_tables(columns: list = None) -> pd.DataFrame:
+def metadata_tables(columns: list = None, metadata_table_path: str = None) -> pd.DataFrame:
     """
     Retrieves the master table of rivers metadata and properties as a pandas DataFrame
     Args:
@@ -211,13 +211,17 @@ def metadata_tables(columns: list = None) -> pd.DataFrame:
     """
     if os.path.exists(METADATA_TABLE_PATH):
         return pd.read_parquet(METADATA_TABLE_PATH, columns=columns)
+
+    if metadata_table_path:
+        return pd.read_parquet(metadata_table_path, columns=columns)
+
     warn = f"""
-    Local copy of geoglows v2 metadata table not found. You should download a copy for optimal performance and 
+    Local copy of geoglows v2 metadata table not found. You should download a copy for optimal performance and
     to make the data available when you are offline. A copy of the table will be cached at {METADATA_TABLE_PATH}.
     Alternatively, set the environment variable PYGEOGLOWS_METADATA_TABLE_PATH to the path of the table.
     """
     warnings.warn(warn)
-    df = pd.read_parquet('https://geoglows-v2.s3-website-us-west-2.amazonaws.com/tables/package-metadata-table.parquet')
+    df = pd.read_parquet('http://geoglows-v2.s3-website-us-west-2.amazonaws.com/tables/package-metadata-table.parquet')
     os.makedirs(os.path.dirname(METADATA_TABLE_PATH), exist_ok=True)
     df.to_parquet(METADATA_TABLE_PATH)
     return df[columns] if columns else df

--- a/geoglows/streams.py
+++ b/geoglows/streams.py
@@ -22,7 +22,7 @@ def river_to_vpu(river_id: int) -> int:
     )
 
 
-def latlon_to_river(lat: float, lon: float) -> int:
+def latlon_to_river(lat: float, lon: float, metadata_table_path: str = None) -> int:
     """
     Gives the River ID number whose outlet is nearest the given lat and lon
     Args:
@@ -32,7 +32,7 @@ def latlon_to_river(lat: float, lon: float) -> int:
     Returns:
         int: a 9 digit integer that is a valid GEOGLOWS River ID number
     """
-    df = metadata_tables(columns=['LINKNO', 'lat', 'lon'])
+    df = metadata_tables(columns=['LINKNO', 'lat', 'lon'], metadata_table_path=metadata_table_path)
     df['dist'] = ((df['lat'] - lat) ** 2 + (df['lon'] - lon) ** 2) ** 0.5
     return df.loc[lambda x: x['dist'] == df['dist'].min(), 'LINKNO'].values[0]
 

--- a/geoglows/streams.py
+++ b/geoglows/streams.py
@@ -28,6 +28,7 @@ def latlon_to_river(lat: float, lon: float, metadata_table_path: str = None) -> 
     Args:
         lat (float): a latitude
         lon (float): a longitude
+        metadata_table_path (str): optional path to the local metadata table
 
     Returns:
         int: a 9 digit integer that is a valid GEOGLOWS River ID number


### PR DESCRIPTION
add metatable as an argument to the stream latlon_to_river function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `metadata_tables` function to accept a local path for metadata tables, improving performance and enabling offline access.
  - Updated the `latlon_to_river` function to allow the use of a local metadata table path, enhancing its functionality.

- **Chores**
  - Updated `.gitignore` to exclude `*.pyc` and `*.parquet` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->