### PR TITLE
Don't fail on new datasets which are already timezone aware

### DIFF
--- a/geoglows/__init__.py
+++ b/geoglows/__init__.py
@@ -12,6 +12,6 @@ __all__ = [
     'bias', 'plots', 'data', 'analyze', 'streams', 'tables', 'streamflow',
     'get_metadata_table_path', 'set_metadata_table_path',
 ]
-__version__ = '1.8.2'
+__version__ = '1.8.3'
 __author__ = 'Riley Hales'
 __license__ = 'BSD 3-Clause Clear License'

--- a/geoglows/_download_decorators.py
+++ b/geoglows/_download_decorators.py
@@ -160,7 +160,10 @@ def _forecast(function):
             if 'datetime' in df.columns:
                 df['datetime'] = pd.to_datetime(df['datetime'])
                 df = df.set_index('datetime')
-                df.index = df.index.tz_localize('UTC')
+                try:
+                    df.index = df.index.tz_localize('UTC')
+                except Exception:
+                    pass
             return df
         elif return_format == 'json':
             return response.json()


### PR DESCRIPTION
Recent revisions to forecast records and versions of pandas/xarray make the forecast records (possibly others) already have a timezone-aware index. wrap in try except so that it can apply if possible else carry on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 1.8.3.
- **Bug Fixes**
  - Enhanced error handling during data processing to improve stability and prevent interruptions from potential timezone-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->