### PR TITLE
Update bucket locations

### DIFF
--- a/geoglows/__init__.py
+++ b/geoglows/__init__.py
@@ -12,6 +12,6 @@ __all__ = [
     'set_uri', 'get_uri'
 ]
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 __author__ = 'Riley Hales'
 __license__ = 'BSD 3-Clause Clear License'

--- a/geoglows/_constants.py
+++ b/geoglows/_constants.py
@@ -20,7 +20,7 @@ default_uri = {
     'sfdc': f'{BUCKET_BASE_URI}/transformers/sfdc.zarr',
     'hydroweb': f'{BUCKET_BASE_URI}/transformers/hydroweb.zarr',
     # tables
-    'transformer_table': f'{BUCKET_BASE_URI}/transformers/transformer_table.parquet',
+    'transformer_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/transformers/transformer_table.parquet',
     'metadata_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/tables/v2-model-table.parquet',
 }
 

--- a/geoglows/_constants.py
+++ b/geoglows/_constants.py
@@ -21,7 +21,7 @@ default_uri = {
     'hydroweb': f'{BUCKET_BASE_URI}/transformers/hydroweb.zarr',
     # tables
     'transformer_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/transformers/transformer_table.parquet',
-    'metadata_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/tables/v2-model-table.parquet',
+    'metadata_table': 'https://geoglows-v2.s3-us-west-2.amazonaws.com/tables/v2-model-table.parquet',
 }
 
 env_keys = {

--- a/geoglows/_constants.py
+++ b/geoglows/_constants.py
@@ -2,6 +2,7 @@ import os
 
 ODP_FORECAST_S3_BUCKET_URI = 's3://geoglows-v2-forecasts'
 ODP_S3_BUCKET_REGION = 'us-west-2'
+BUCKET_BASE_URI = f's3://geoglows-v2'
 DEFAULT_REST_ENDPOINT = 'https://geoglows.ecmwf.int/api/'
 DEFAULT_REST_ENDPOINT_VERSION = 'v2'  # 'v1, v2, latest'
 
@@ -9,18 +10,18 @@ default_uri = {
     # forecasts
 
     # retrospective
-    'retro_hourly': 's3://rfs-v2/retrospective/hourly.zarr',
-    'retro_daily': 's3://rfs-v2/retrospective/daily.zarr',
-    'retro_monthly': 's3://rfs-v2/retrospective/monthly-timeseries.zarr',
-    'retro_yearly': 's3://rfs-v2/retrospective/yearly-timeseries.zarr',
-    'fdc': 's3://rfs-v2/retrospective/fdc.zarr',
-    'return_periods': 's3://rfs-v2/retrospective/return-periods.zarr',
+    'retro_hourly': f'{BUCKET_BASE_URI}/retrospective/hourly.zarr',
+    'retro_daily': f'{BUCKET_BASE_URI}/retrospective/daily.zarr',
+    'retro_monthly': f'{BUCKET_BASE_URI}/retrospective/monthly-timeseries.zarr',
+    'retro_yearly': f'{BUCKET_BASE_URI}/retrospective/yearly-timeseries.zarr',
+    'fdc': f'{BUCKET_BASE_URI}/retrospective/fdc.zarr',
+    'return_periods': f'{BUCKET_BASE_URI}/retrospective/return-periods.zarr',
     # transformers
-    'sfdc': 's3://rfs-v2/transformers/sfdc.zarr',
-    'hydroweb': 's3://rfs-v2/transformers/hydroweb.zarr',
+    'sfdc': f'{BUCKET_BASE_URI}/transformers/sfdc.zarr',
+    'hydroweb': f'{BUCKET_BASE_URI}/transformers/hydroweb.zarr',
     # tables
-    'transformer_table': 's3://rfs-v2/transformers/transformer_table.parquet',
-    'metadata_table': 'https://rfs-v2.s3-us-west-2.amazonaws.com/tables/model-metadata-table.parquet',
+    'transformer_table': f'{BUCKET_BASE_URI}/transformers/transformer_table.parquet',
+    'metadata_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/tables/v2-model-table.parquet',
 }
 
 env_keys = {

--- a/geoglows/_constants.py
+++ b/geoglows/_constants.py
@@ -2,7 +2,7 @@ import os
 
 ODP_FORECAST_S3_BUCKET_URI = 's3://geoglows-v2-forecasts'
 ODP_S3_BUCKET_REGION = 'us-west-2'
-BUCKET_BASE_URI = f's3://geoglows-v2'
+BUCKET_BASE_URI = 's3://geoglows-v2'
 DEFAULT_REST_ENDPOINT = 'https://geoglows.ecmwf.int/api/'
 DEFAULT_REST_ENDPOINT_VERSION = 'v2'  # 'v1, v2, latest'
 
@@ -20,7 +20,7 @@ default_uri = {
     'sfdc': f'{BUCKET_BASE_URI}/transformers/sfdc.zarr',
     'hydroweb': f'{BUCKET_BASE_URI}/transformers/hydroweb.zarr',
     # tables
-    'transformer_table': 'http://geoglows-v2.s3-us-west-2.amazonaws.com/transformers/transformer_table.parquet',
+    'transformer_table': 'https://geoglows-v2.s3-us-west-2.amazonaws.com/transformers/transformer_table.parquet',
     'metadata_table': 'https://geoglows-v2.s3-us-west-2.amazonaws.com/tables/v2-model-table.parquet',
 }
 

--- a/geoglows/_download_decorators.py
+++ b/geoglows/_download_decorators.py
@@ -202,7 +202,7 @@ def _retrospective(function):
                           json={'river_id': river_id, 'product': product_name, 'format': return_format})
 
         uri = get_uri(product_name)
-        storage_options = {'anon': True} if uri.startswith('s3://rfs-v2') else None
+        storage_options = {'anon': True} if uri.startswith('s3://geoglows-v2') else None
         storage_options = kwargs.get('storage_options', storage_options)
 
         with xr.open_zarr(uri, zarr_format=2, storage_options=storage_options) as ds:

--- a/geoglows/data.py
+++ b/geoglows/data.py
@@ -292,7 +292,7 @@ def sfdc(*, curve_id: int or list = None, river_id: int or list = None) -> pd.Da
         curve_id = pd.read_parquet(get_uri('transformer_table')).loc[river_id, 'sfdc_curve_id']
 
     uri = get_uri('sfdc')
-    storage_options = {'anon': True} if uri.startswith('s3://rfs-v2') else None
+    storage_options = {'anon': True} if uri.startswith('s3://geoglows-v2') else None
     return (
         xr
         .open_zarr(uri, storage_options=storage_options)
@@ -314,7 +314,7 @@ def hydroweb_wse_transformer(river_id: int) -> pd.DataFrame:
         pd.DataFrame
     """
     uri = get_uri('hydroweb')
-    storage_options = {'anon': True} if uri.startswith('s3://rfs-v2') else None
+    storage_options = {'anon': True} if uri.startswith('s3://geoglows-v2') else None
     with xr.open_zarr(uri, storage_options=storage_options) as ds:
         try:
             return ds.sel(river_id=river_id).to_dataframe()[['wse']]


### PR DESCRIPTION
Updates AWS S3 URIs for all resources to avoid the postponed v2.1/3 transition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated version number to 2.0.1.
  - Changed storage URIs to use a new base location for all S3 resources.
  - Updated metadata table link to a new domain and filename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->